### PR TITLE
Adjust sample-app devcontainer ports for side-by-side stacks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,5 @@
 	"service": "laravel",
 	"workspaceFolder": "/var/www/html",
 	"remoteUser": "laravel",
-	"forwardPorts": [80]
+	"forwardPorts": [18080]
 }

--- a/.devcontainer/docker/docker-compose.yml
+++ b/.devcontainer/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: sample-app
+
 services:
     laravel:
         build:
@@ -6,8 +8,8 @@ services:
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:
-            - '${APP_PORT:-80}:80'
-            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+            - '${APP_PORT:-18080}:80'
+            - '${VITE_PORT:-15173}:${VITE_PORT:-15173}'
         volumes:
             - '../../:/var/www/html'
         networks:
@@ -22,7 +24,7 @@ services:
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:
-            - '8001:80'
+            - '${MICROSERVICE_PORT:-18001}:80'
         volumes:
             - '../../microservice:/var/www/html'
         networks:
@@ -34,7 +36,7 @@ services:
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
+            - '${FORWARD_DB_PORT:-13306}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD:-password}'
             MYSQL_ROOT_HOST: "%"
@@ -54,7 +56,7 @@ services:
     redis:
         image: 'redis:alpine'
         ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
+            - '${FORWARD_REDIS_PORT:-16379}:6379'
         volumes:
             - 'laravel-redis:/data'
         networks:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ php artisan app:workflow
 ```
 
 ### Step 8
-You can view the waterline dashboard at https://[your-codespace-name]-80.preview.app.github.dev/waterline/dashboard.
+You can view the waterline dashboard at https://[your-codespace-name]-18080.preview.app.github.dev/waterline/dashboard.
 
 <img src="https://user-images.githubusercontent.com/1130888/233669600-3340ada6-5f73-4602-8d82-a81a9d43f883.png" alt="image" width="600">
 

--- a/app/Console/Commands/Init.php
+++ b/app/Console/Commands/Init.php
@@ -211,7 +211,7 @@ class Init extends Command
             return;
         }
 
-        $assetUrl = "https://{$codespaceName}-80.{$portDomain}";
+        $assetUrl = "https://{$codespaceName}-18080.{$portDomain}";
 
         if ($this->setEnvVariable('ASSET_URL', $assetUrl)) {
             $this->info('ASSET_URL set successfully in .env file.');
@@ -231,7 +231,7 @@ class Init extends Command
             return;
         }
 
-        $realUrl = "https://{$codespaceName}-80.{$portDomain}";
+        $realUrl = "https://{$codespaceName}-18080.{$portDomain}";
 
         $readmeFile = base_path('README.md');
         if (!file_exists($readmeFile)) {
@@ -241,7 +241,7 @@ class Init extends Command
 
         $readmeContents = file_get_contents($readmeFile);
         $updatedReadme = preg_replace(
-            '/https:\/\/\[your-codespace-name\]-80\.preview\.app\.github\.dev/',
+            '/https:\/\/\[your-codespace-name\]-18080\.preview\.app\.github\.dev/',
             $realUrl,
             $readmeContents
         );


### PR DESCRIPTION
## Summary
- remap the sample app devcontainer ports to avoid collisions with other local stacks
- update the Codespaces README URL to use the new forwarded app port
- update `app:init` so generated `ASSET_URL` and README replacements use the remapped port

## Notes
- checked the branch for other non-vendor port references; no further app-level updates were needed
