### PR TITLE
Bump polyglot server pin to 0.2.110

### DIFF
--- a/polyglot/docker-compose.yml
+++ b/polyglot/docker-compose.yml
@@ -62,10 +62,10 @@ services:
       timeout: 2s
       retries: 10
 
-  # Server image pin: 0.2.108 contains the polyglot routing and PHP-to-Python
-  # workflow completion fixes needed by the cross-language smoke.
+  # Server image pin: 0.2.110 includes the workflow/activity poll replay fixes
+  # exercised by the published cross-language smoke.
   bootstrap:
-    image: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.108}"
+    image: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.110}"
     command: ["server-bootstrap"]
     environment: *server-env
     depends_on:
@@ -75,7 +75,7 @@ services:
         condition: service_healthy
 
   server:
-    image: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.108}"
+    image: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.110}"
     ports:
       - "${SERVER_PORT:-8080}:8080"
     environment: *server-env
@@ -138,7 +138,7 @@ services:
       DURABLE_WORKFLOW_SERVER_URL: "http://server:8080"
       DURABLE_WORKFLOW_AUTH_TOKEN: "test-token"
       DURABLE_WORKFLOW_NAMESPACE: default
-      DURABLE_SERVER_IMAGE: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.108}"
+      DURABLE_SERVER_IMAGE: "${DURABLE_SERVER_IMAGE:-durableworkflow/server:0.2.110}"
       POLYGLOT_PY_TASK_QUEUE: polyglot-python
       POLYGLOT_PHP2PY_TASK_QUEUE: polyglot-php-to-python
     depends_on:

--- a/polyglot/python_worker/scripts/smoke.sh
+++ b/polyglot/python_worker/scripts/smoke.sh
@@ -9,7 +9,7 @@ scripts_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 : "${DURABLE_WORKFLOW_SERVER_URL:?DURABLE_WORKFLOW_SERVER_URL must be set}"
 : "${DURABLE_WORKFLOW_AUTH_TOKEN:=test-token}"
 : "${DURABLE_WORKFLOW_NAMESPACE:=default}"
-: "${DURABLE_SERVER_IMAGE:=durableworkflow/server:0.2.96}"
+: "${DURABLE_SERVER_IMAGE:=durableworkflow/server:0.2.110}"
 export DURABLE_WORKFLOW_SERVER_URL DURABLE_WORKFLOW_AUTH_TOKEN DURABLE_WORKFLOW_NAMESPACE
 
 printf '\n==> polyglot smoke: server image %s\n' "$DURABLE_SERVER_IMAGE"


### PR DESCRIPTION
## Summary
- bump the sample-app polyglot compose stack from durableworkflow/server:0.2.108 to durableworkflow/server:0.2.110
- align the smoke script fallback pin with the compose pin so manual runs exercise the same published server
- keep the public polyglot sample consuming the current released server fixes

## Validation
- docker compose up -d --build --wait server python-activity-worker php-workflow-worker python-workflow-worker
- docker compose run --rm --build smoke
- docker compose down -v --remove-orphans
- smoke passed on durableworkflow/server:0.2.110 for both python_workflow and php_to_python scenarios