### PR TITLE
Bump polyglot Python SDK to 0.4.35

### DIFF
--- a/polyglot/python_worker/Dockerfile
+++ b/polyglot/python_worker/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir "durable-workflow==0.4.22"
+RUN pip install --no-cache-dir "durable-workflow==0.4.35"
 
 COPY activities.py ./activities.py
 # Bake the polyglot smoke scripts into the image so the smoke service does

--- a/polyglot/python_workflow/Dockerfile
+++ b/polyglot/python_workflow/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir 'durable-workflow==0.4.22'
+RUN pip install --no-cache-dir 'durable-workflow==0.4.35'
 
 COPY workflow.py ./workflow.py
 


### PR DESCRIPTION
## Summary
- bump the sample-app polyglot Python workflow and activity images from durable-workflow 0.4.22 to 0.4.35
- align the public sample with the current released Python SDK that includes workflow/activity poll replay fixes
- address the main-branch polyglot-validation timeout where the python_workflow scenario stayed pending on server 0.2.110

## Validation
- docker compose down -v --remove-orphans || true
- docker compose up -d --build --wait server python-activity-worker php-workflow-worker python-workflow-worker
- docker compose run --rm --build smoke
- docker compose down -v --remove-orphans
- result: polyglot smoke passed on durableworkflow/server:0.2.110 with durable-workflow 0.4.35 for both python_workflow and php_to_python scenarios