### PR TITLE
Include ripgrep in the Codespaces image

### DIFF
--- a/.devcontainer/docker/Dockerfile
+++ b/.devcontainer/docker/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
         python3-pip \
         python3-venv \
         redis-tools \
+        ripgrep \
         sqlite3 \
         supervisor \
         unzip \

--- a/.devcontainer/docker/verify-image.sh
+++ b/.devcontainer/docker/verify-image.sh
@@ -16,7 +16,7 @@ for extension in bcmath curl gd intl mbstring pcntl pdo_mysql pdo_sqlite redis z
     php --ri "$extension" >/dev/null
 done
 
-for executable in cargo cc composer curl docker dw ffmpeg git make mysql node npm npx pip pip3 pkg-config playwright python python3 redis-cli rustc ssh sshd; do
+for executable in cargo cc composer curl docker dw ffmpeg git make mysql node npm npx pip pip3 pkg-config playwright python python3 redis-cli rg rustc ssh sshd; do
     command -v "$executable" >/dev/null
 done
 

--- a/tests/Unit/DevcontainerImageContractTest.php
+++ b/tests/Unit/DevcontainerImageContractTest.php
@@ -196,6 +196,7 @@ final class DevcontainerImageContractTest extends TestCase
         $this->assertLessThan($postPurgeExtensionCheck, $dependencyPurge);
         $this->assertStringContainsString('default-mysql-client', $dockerfile);
         $this->assertStringContainsString('redis-tools', $dockerfile);
+        $this->assertStringContainsString('ripgrep', $dockerfile);
         $this->assertStringContainsString('ffmpeg', $dockerfile);
         $this->assertStringContainsString('libcap2-bin', $dockerfile);
         $this->assertStringContainsString('openssh-server', $dockerfile);
@@ -238,6 +239,7 @@ final class DevcontainerImageContractTest extends TestCase
             'playwright',
             'python',
             'redis-cli',
+            'rg',
             'rustc',
             'ssh',
             'sshd',


### PR DESCRIPTION
## Summary
- install `ripgrep` in the prebuilt development image
- require `rg` in image qualification
- cover the package and executable contract in the devcontainer test

## Verification
- focused devcontainer image contract: 131 assertions passed
- candidate image workflow will build and run the in-image qualification before merge