### PR TITLE
Link organization-wide agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Repository agent guidance
 
+Follow the [Durable Workflow organization-wide agent guide](https://github.com/durable-workflow/.github/blob/main/AGENTS.md).
+The instructions below are repository-specific additions.
+
 When a user asks to create and run a Durable Workflow workflow and activity,
 start with the repository playground instead of the conformance matrix.
 


### PR DESCRIPTION
Part of durable-workflow/.github#95.

Adds a root `AGENTS.md` pointer to the public organization-wide guide so a human or agent starting from this repository can discover the shared product, issue, security, conformance, and release rules. Existing repository-specific guidance is preserved.

Validation: `git diff --check`.