### PR TITLE
Preserve playground readiness diagnostics

### DIFF
--- a/scripts/playground
+++ b/scripts/playground
@@ -782,7 +782,21 @@ def dw_environment(
 def json_command(
     command: list[str], *, env: dict[str, str], timeout: float = 30
 ) -> dict[str, Any]:
-    result = run(command, env=env, capture=True, timeout=timeout)
+    try:
+        result = run(command, env=env, capture=True, timeout=timeout)
+    except subprocess.CalledProcessError as error:
+        details = []
+        for output in (error.stderr, error.stdout):
+            detail = (output or "").strip()
+            if detail and detail not in details:
+                details.append(detail)
+        message = (
+            f"{shlex.join(command)} failed with exit status {error.returncode}"
+        )
+        if details:
+            message = f"{message}:\n" + "\n".join(details)
+        raise PlaygroundError(message) from error
+
     try:
         value = json.loads(result.stdout)
     except json.JSONDecodeError as error:

--- a/tests/Unit/PlaygroundContractTest.php
+++ b/tests/Unit/PlaygroundContractTest.php
@@ -439,6 +439,30 @@ assert [worker["worker_id"] for worker in roster["workers"]] == [
     "stale-worker",
     "current-worker",
 ]
+
+clock = {"now": 0}
+def failed_roster(command, *, env, timeout=30):
+    raise PlaygroundError("dw worker:list failed with exit status 8: compatible client required")
+
+globals["json_command"] = failed_roster
+globals["time"].monotonic = lambda: clock["now"]
+globals["time"].sleep = lambda seconds: clock.update(now=61)
+try:
+    wait_for_registration(
+        "shared-queue",
+        "current-worker",
+        "authored-workflow",
+        "authored-activity",
+        "https://runtime.example/namespaces/example",
+        "example",
+        "client-secret",
+        FakeWorker(),
+    )
+except PlaygroundError as error:
+    assert "compatible client required" in str(error)
+else:
+    raise AssertionError("The final readiness error discarded the roster diagnostic")
+
 print("invocation-registration-proof=ready")
 PYTHON;
 
@@ -452,6 +476,60 @@ PYTHON;
 
         $this->assertStringContainsString(
             'invocation-registration-proof=ready',
+            $process->getOutput(),
+        );
+    }
+
+    public function test_managed_readiness_preserves_the_cli_failure_diagnostic(): void
+    {
+        $harness = <<<'PYTHON'
+import runpy
+import subprocess
+import sys
+
+playground = runpy.run_path(sys.argv[1])
+json_command = playground["json_command"]
+PlaygroundError = playground["PlaygroundError"]
+globals = json_command.__globals__
+
+def fail(command, *, env=None, cwd=None, capture=False, timeout=None):
+    raise subprocess.CalledProcessError(
+        8,
+        command,
+        output='{"error":"client_version_unsupported"}',
+        stderr="The installed client is outside the server-advertised supported range.",
+    )
+
+globals["run"] = fail
+
+try:
+    json_command(
+        ["dw", "worker:list", "--task-queue=managed queue", "--json"],
+        env={},
+    )
+except PlaygroundError as error:
+    message = str(error)
+    assert "dw 'worker:list'" not in message
+    assert "dw worker:list '--task-queue=managed queue' --json" in message
+    assert "exit status 8" in message
+    assert "client_version_unsupported" in message
+    assert "outside the server-advertised supported range" in message
+else:
+    raise AssertionError("A failed roster command did not raise PlaygroundError")
+
+print("managed-readiness-diagnostic=preserved")
+PYTHON;
+
+        $process = new Process([
+            'python3',
+            '-c',
+            $harness,
+            $this->path('scripts/playground'),
+        ]);
+        $process->mustRun();
+
+        $this->assertStringContainsString(
+            'managed-readiness-diagnostic=preserved',
             $process->getOutput(),
         );
     }


### PR DESCRIPTION
Closes #75.

## What changed

- include the failed command, exit status, stderr, and stdout when a JSON-producing CLI command fails
- retain the strict worker registration proof and preserve the final actionable roster error
- add focused subprocess and timeout regression coverage

## Local verification

- Python AST parse
- Pint on `PlaygroundContractTest`
- focused readiness tests passed
- the complete `PlaygroundContractTest` reached 14 passing tests; two environment-only cases require the image-baked SDK runtime and a Git worktree inside the test container, both supplied by GitHub Actions

The underlying stable Server compatibility correction is durable-workflow/server#89.