### PR TITLE
Clarify managed Waterline evidence omission

### DIFF
--- a/playground/contract.json
+++ b/playground/contract.json
@@ -52,7 +52,7 @@
       "managed": {
         "selected_waterline_run": {
           "requirement": "omitted",
-          "reason": "managed-runtime-waterline-not-provisioned"
+          "reason": "managed-waterline-not-validated-by-sdk-playground"
         }
       }
     }

--- a/tests/Unit/PlaygroundContractTest.php
+++ b/tests/Unit/PlaygroundContractTest.php
@@ -45,7 +45,7 @@ final class PlaygroundContractTest extends TestCase
         $this->assertSame(
             [
                 'requirement' => 'omitted',
-                'reason' => 'managed-runtime-waterline-not-provisioned',
+                'reason' => 'managed-waterline-not-validated-by-sdk-playground',
             ],
             $contract['proof']['runtime']['managed']['selected_waterline_run'] ?? null,
         );
@@ -655,7 +655,7 @@ for language in ("php", "python", "rust"):
     assert payload["workflow"]["worker_id"] == active["worker_id"]
     assert payload["waterline"] == {
         "status": "omitted",
-        "reason": "managed-runtime-waterline-not-provisioned",
+        "reason": "managed-waterline-not-validated-by-sdk-playground",
     }
     summaries.append(payload["language"])
     evidence_paths.append(evidence_path)


### PR DESCRIPTION
Closes #77.

Managed SDK journeys cannot validate the authenticated Cloud Waterline UI. Report that bounded omission directly instead of claiming the managed runtime did not provision Waterline. Local Waterline selection proof is unchanged.

Validation:
- `test_playground_exposes_symmetric_authored_scenarios`: 54 assertions
- `test_managed_runtime_keeps_worker_and_client_roles_isolated_for_every_sdk`: 5 assertions
- `git diff --check`
