### PR TITLE
Qualify Rust SDK 2.0.1

### DIFF
--- a/playground/templates/rust/Cargo.lock
+++ b/playground/templates/rust/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "durable-workflow"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e22310a10fefd3ee2118a260f5255b98c607856b73749629505891fc18aae49"
+checksum = "667c48e7a79c8a2891b25990d481b4af6907fced01d573658b491fa48cbe0aec"
 dependencies = [
  "apache-avro",
  "base64",

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -6,7 +6,7 @@
     "cli": "2.0.0",
     "sdk-php": "2.0.0",
     "sdk-python": "2.0.0",
-    "sdk-rust": "2.0.0",
+    "sdk-rust": "2.0.1",
     "server": "2.0.0",
     "waterline": "2.0.0",
     "workflow": "2.0.2"


### PR DESCRIPTION
## Summary

- advance the qualified Rust SDK artifact to `2.0.1`
- refresh only the Rust playground package entry and checksum in the locked dependency graph

## Validation

- focused qualified-artifact/lock consistency test
- `cargo check --locked --manifest-path playground/templates/rust/Cargo.toml --bins`

Closes #79