### PR TITLE
Adopt Workflow 2.0.12 scheduler precision fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -915,16 +915,16 @@
         },
         {
             "name": "durable-workflow/workflow",
-            "version": "2.0.11",
+            "version": "2.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/workflow.git",
-                "reference": "91123158bfd87467fd6c3d420b26ad1965d226fd"
+                "reference": "39940444228086d8d888ef8061cd67df8cbba8c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/91123158bfd87467fd6c3d420b26ad1965d226fd",
-                "reference": "91123158bfd87467fd6c3d420b26ad1965d226fd",
+                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/39940444228086d8d888ef8061cd67df8cbba8c2",
+                "reference": "39940444228086d8d888ef8061cd67df8cbba8c2",
                 "shasum": ""
             },
             "require": {
@@ -957,7 +957,7 @@
                     "dev-main": "2.0.x-dev"
                 },
                 "durable-workflow": {
-                    "product-train": "2.0.11",
+                    "product-train": "2.0.12",
                     "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
                     "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
                 }
@@ -984,9 +984,9 @@
             "description": "Embedded durable workflow runtime and orchestration engine for Laravel applications.",
             "support": {
                 "issues": "https://github.com/durable-workflow/workflow/issues",
-                "source": "https://github.com/durable-workflow/workflow/tree/2.0.11"
+                "source": "https://github.com/durable-workflow/workflow/tree/2.0.12"
             },
-            "time": "2026-09-09T19:04:54+00:00"
+            "time": "2026-09-09T23:59:39+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -9,6 +9,6 @@
     "sdk-rust": "2.0.1",
     "server": "2.0.0",
     "waterline": "2.0.0",
-    "workflow": "2.0.11"
+    "workflow": "2.0.12"
   }
 }


### PR DESCRIPTION
## Change
Update the embedded Workflow lock entry and qualified-artifact manifest to published 2.0.12 (39940444), fixing due-schedule timestamp precision. No SDK, Laravel or other dependency changes.

Part of durable-workflow/workflow#505 delivery. The existing Composer constraint admits this patch.

## Verification
Composer resolution, validation and artifact-graph checks pass. The initial CI failure identified the omitted manifest update; it was corrected on this branch. PHP 8.4/8.5 application checks, Docker sample workflows and PHP/Python/Rust smoke pass. Candidate image validation is running; prepared image publication follows merge.

The separately pinned service-mode Server remains unchanged here; its scheduler fix is being delivered through durable-workflow/server#156 and will need its own Sample App artifact adoption.