### PR TITLE
Adopt Server 2.3.10 payload repair

### DIFF
--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -7,7 +7,7 @@
     "sdk-php": "2.0.0",
     "sdk-python": "2.0.0",
     "sdk-rust": "2.0.1",
-    "server": "2.3.9",
+    "server": "2.3.10",
     "waterline": "2.0.0",
     "workflow": "2.0.12"
   }


### PR DESCRIPTION
## Summary
Adopts the Server fix from durable-workflow/server#157 and durable-workflow/server#158 in the single qualified artifact tuple. No SDK, CLI, Workflow or Waterline version changes.

The published Server 2.3.10 image has passed a fresh-container retained-payload repair and authenticated HTTP-kernel fetch check; source CI passed 2,187 tests and the repository's topology, upgrade, performance and Helm checks.

## Validation
- [x] Artifact resolver selects Server 2.3.10 while preserving the other six artifacts.
- [x] Application and microservice CI (PHP 8.4 and 8.5).
- [x] Published PHP workflow + Python/Rust activities.
- [x] Prepared Codespaces image qualification.
- [x] Merged at `5aa3572bbf6928f5fae22037c9dfd0072d6a33c9`.
- [x] Publish and qualify amd64/arm64 development images; both GHCR and Docker Hub `main` match the immutable revision tag. [Publication and qualification](https://github.com/durable-workflow/sample-app/actions/runs/34450246523).

Keep release follow-through on server#157 and these PRs; no separate tracking issue is needed.