### PR TITLE
Adopt published PHP polling and Workflow projection fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -720,16 +720,16 @@
         },
         {
             "name": "durable-workflow/sdk",
-            "version": "2.0.0",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/sdk-php.git",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf"
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/af7931e79683adf55bfa87cd7b3b90561bc137cf",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf",
+                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
                 "shasum": ""
             },
             "require": {
@@ -770,7 +770,7 @@
                         "laravel": "^9.0|^10.0|^11.0|^12.0|^13.0",
                         "symfony": "^6.4|^7.0|^8.0"
                     },
-                    "product-train": "2.0.0",
+                    "product-train": "2.0.10",
                     "payload-codecs": [
                         "avro"
                     ],
@@ -798,7 +798,7 @@
                         "deprecatePatch"
                     ],
                     "worker-protocol-version": "1.19",
-                    "supported-server-versions": "2.0.0",
+                    "supported-server-versions": "2.1.0",
                     "version-marker-history-event": "VersionMarkerRecorded",
                     "message-streams-minimum-worker-protocol-version": "1.15",
                     "durable-selection-minimum-worker-protocol-version": "1.19"
@@ -818,12 +818,16 @@
                     "name": "Durable Workflow Contributors"
                 }
             ],
-            "description": "Framework-neutral PHP client and worker SDK for the Durable Workflow server",
-            "homepage": "https://durable-workflow.com",
+            "description": "PHP client and worker SDK for Durable Workflow Cloud and self-hosted Server",
+            "homepage": "https://php.durable-workflow.com/",
             "keywords": [
+                "cloud",
                 "durable",
+                "laravel",
                 "orchestration",
+                "php",
                 "sdk",
+                "symfony",
                 "worker",
                 "workflow"
             ],
@@ -832,7 +836,7 @@
                 "issues": "https://github.com/durable-workflow/sdk-php/issues",
                 "source": "https://github.com/durable-workflow/sdk-php"
             },
-            "time": "2026-09-01T01:00:27+00:00"
+            "time": "2026-09-11T15:26:39+00:00"
         },
         {
             "name": "durable-workflow/waterline",
@@ -915,16 +919,16 @@
         },
         {
             "name": "durable-workflow/workflow",
-            "version": "2.0.12",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/workflow.git",
-                "reference": "39940444228086d8d888ef8061cd67df8cbba8c2"
+                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/39940444228086d8d888ef8061cd67df8cbba8c2",
-                "reference": "39940444228086d8d888ef8061cd67df8cbba8c2",
+                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/3fff6e737a92854a48b28dede8f7654f198cf7a5",
+                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5",
                 "shasum": ""
             },
             "require": {
@@ -957,7 +961,7 @@
                     "dev-main": "2.0.x-dev"
                 },
                 "durable-workflow": {
-                    "product-train": "2.0.12",
+                    "product-train": "2.0.13",
                     "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
                     "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
                 }
@@ -984,9 +988,9 @@
             "description": "Embedded durable workflow runtime and orchestration engine for Laravel applications.",
             "support": {
                 "issues": "https://github.com/durable-workflow/workflow/issues",
-                "source": "https://github.com/durable-workflow/workflow/tree/2.0.12"
+                "source": "https://github.com/durable-workflow/workflow/tree/2.0.13"
             },
-            "time": "2026-09-09T23:59:39+00:00"
+            "time": "2026-09-11T19:03:42+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/microservice/composer.lock
+++ b/microservice/composer.lock
@@ -505,16 +505,16 @@
         },
         {
             "name": "durable-workflow/sdk",
-            "version": "2.0.0",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/sdk-php.git",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf"
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/af7931e79683adf55bfa87cd7b3b90561bc137cf",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf",
+                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
                 "shasum": ""
             },
             "require": {
@@ -555,7 +555,7 @@
                         "laravel": "^9.0|^10.0|^11.0|^12.0|^13.0",
                         "symfony": "^6.4|^7.0|^8.0"
                     },
-                    "product-train": "2.0.0",
+                    "product-train": "2.0.10",
                     "payload-codecs": [
                         "avro"
                     ],
@@ -583,7 +583,7 @@
                         "deprecatePatch"
                     ],
                     "worker-protocol-version": "1.19",
-                    "supported-server-versions": "2.0.0",
+                    "supported-server-versions": "2.1.0",
                     "version-marker-history-event": "VersionMarkerRecorded",
                     "message-streams-minimum-worker-protocol-version": "1.15",
                     "durable-selection-minimum-worker-protocol-version": "1.19"
@@ -603,12 +603,16 @@
                     "name": "Durable Workflow Contributors"
                 }
             ],
-            "description": "Framework-neutral PHP client and worker SDK for the Durable Workflow server",
-            "homepage": "https://durable-workflow.com",
+            "description": "PHP client and worker SDK for Durable Workflow Cloud and self-hosted Server",
+            "homepage": "https://php.durable-workflow.com/",
             "keywords": [
+                "cloud",
                 "durable",
+                "laravel",
                 "orchestration",
+                "php",
                 "sdk",
+                "symfony",
                 "worker",
                 "workflow"
             ],
@@ -617,7 +621,7 @@
                 "issues": "https://github.com/durable-workflow/sdk-php/issues",
                 "source": "https://github.com/durable-workflow/sdk-php"
             },
-            "time": "2026-09-01T01:00:27+00:00"
+            "time": "2026-09-11T15:26:39+00:00"
         },
         {
             "name": "durable-workflow/waterline",
@@ -700,16 +704,16 @@
         },
         {
             "name": "durable-workflow/workflow",
-            "version": "2.0.2",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/workflow.git",
-                "reference": "7b9c8308d14a3e8695fdf46a1a871cab8488c3e1"
+                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/7b9c8308d14a3e8695fdf46a1a871cab8488c3e1",
-                "reference": "7b9c8308d14a3e8695fdf46a1a871cab8488c3e1",
+                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/3fff6e737a92854a48b28dede8f7654f198cf7a5",
+                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5",
                 "shasum": ""
             },
             "require": {
@@ -738,8 +742,11 @@
                         "Workflow\\Providers\\WorkflowServiceProvider"
                     ]
                 },
+                "branch-alias": {
+                    "dev-main": "2.0.x-dev"
+                },
                 "durable-workflow": {
-                    "product-train": "2.0.2",
+                    "product-train": "2.0.13",
                     "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
                     "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
                 }
@@ -766,9 +773,9 @@
             "description": "Embedded durable workflow runtime and orchestration engine for Laravel applications.",
             "support": {
                 "issues": "https://github.com/durable-workflow/workflow/issues",
-                "source": "https://github.com/durable-workflow/workflow/tree/2.0.2"
+                "source": "https://github.com/durable-workflow/workflow/tree/2.0.13"
             },
-            "time": "2026-09-01T08:31:26+00:00"
+            "time": "2026-09-11T19:03:42+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/playground/php-runtime/composer.lock
+++ b/playground/php-runtime/composer.lock
@@ -70,16 +70,16 @@
         },
         {
             "name": "durable-workflow/sdk",
-            "version": "2.0.0",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/sdk-php.git",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf"
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/af7931e79683adf55bfa87cd7b3b90561bc137cf",
-                "reference": "af7931e79683adf55bfa87cd7b3b90561bc137cf",
+                "url": "https://api.github.com/repos/durable-workflow/sdk-php/zipball/19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
+                "reference": "19b2695d0bbfb37f0dd1ac54632bd5b1d5023b67",
                 "shasum": ""
             },
             "require": {
@@ -120,7 +120,7 @@
                         "laravel": "^9.0|^10.0|^11.0|^12.0|^13.0",
                         "symfony": "^6.4|^7.0|^8.0"
                     },
-                    "product-train": "2.0.0",
+                    "product-train": "2.0.10",
                     "payload-codecs": [
                         "avro"
                     ],
@@ -148,7 +148,7 @@
                         "deprecatePatch"
                     ],
                     "worker-protocol-version": "1.19",
-                    "supported-server-versions": "2.0.0",
+                    "supported-server-versions": "2.1.0",
                     "version-marker-history-event": "VersionMarkerRecorded",
                     "message-streams-minimum-worker-protocol-version": "1.15",
                     "durable-selection-minimum-worker-protocol-version": "1.19"
@@ -168,12 +168,16 @@
                     "name": "Durable Workflow Contributors"
                 }
             ],
-            "description": "Framework-neutral PHP client and worker SDK for the Durable Workflow server",
-            "homepage": "https://durable-workflow.com",
+            "description": "PHP client and worker SDK for Durable Workflow Cloud and self-hosted Server",
+            "homepage": "https://php.durable-workflow.com/",
             "keywords": [
+                "cloud",
                 "durable",
+                "laravel",
                 "orchestration",
+                "php",
                 "sdk",
+                "symfony",
                 "worker",
                 "workflow"
             ],
@@ -182,7 +186,7 @@
                 "issues": "https://github.com/durable-workflow/sdk-php/issues",
                 "source": "https://github.com/durable-workflow/sdk-php"
             },
-            "time": "2026-09-01T01:00:27+00:00"
+            "time": "2026-09-11T15:26:39+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -4,11 +4,11 @@
   "source": "polyglot/qualified-artifact-tuple.json",
   "artifacts": {
     "cli": "2.0.0",
-    "sdk-php": "2.0.0",
+    "sdk-php": "2.0.10",
     "sdk-python": "2.0.0",
     "sdk-rust": "2.0.1",
     "server": "2.3.10",
     "waterline": "2.0.0",
-    "workflow": "2.0.12"
+    "workflow": "2.0.13"
   }
 }

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -7,7 +7,7 @@
     "sdk-php": "2.0.10",
     "sdk-python": "2.0.0",
     "sdk-rust": "2.0.1",
-    "server": "2.3.10",
+    "server": "2.3.11",
     "waterline": "2.0.0",
     "workflow": "2.0.13"
   }


### PR DESCRIPTION
## Change

Consume published PHP SDK 2.0.10 and Workflow 2.0.13 in the main app, microservice example, and standalone PHP playground lockfiles. Align the qualified artifact tuple with those packages and published Server 2.3.11, which bundles Workflow 2.0.13; all unrelated dependencies and language SDKs are unchanged.

This carries the workflow-poll backpressure repair from durable-workflow/sdk-php#66 and monitoring projection improvement from durable-workflow/workflow#508 into the first-user examples. The microservice example also catches up from Workflow 2.0.2.

## Validation

Targeted Composer resolution/audit, artifact-graph consistency, diff, and public-boundary checks passed. Upstream published-package validation passed for both patches. Application/microservice tests and prepared-image first-user qualification must pass before merge.

Server 2.3.11 publication and matching Helm chart 0.1.90 passed [release verification](https://github.com/durable-workflow/server/actions/runs/34641088799), including exact image/package identity, source-free Compose bootstrap and clean chart install. Its published image also passed seven focused timer/replay scenarios. The prior PHP-only update passed all Sample App checks; the final Server tuple update is now running the same application, polyglot and prepared-image checks. No new capacity claim is inferred from dependency resolution alone.
