### PR TITLE
Adopt published deterministic workflow clock fix

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -919,16 +919,16 @@
         },
         {
             "name": "durable-workflow/workflow",
-            "version": "2.0.13",
+            "version": "2.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/durable-workflow/workflow.git",
-                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5"
+                "reference": "259c32b86d132bdbac683e3bbc1de44251d45c5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/3fff6e737a92854a48b28dede8f7654f198cf7a5",
-                "reference": "3fff6e737a92854a48b28dede8f7654f198cf7a5",
+                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/259c32b86d132bdbac683e3bbc1de44251d45c5d",
+                "reference": "259c32b86d132bdbac683e3bbc1de44251d45c5d",
                 "shasum": ""
             },
             "require": {
@@ -961,7 +961,7 @@
                     "dev-main": "2.0.x-dev"
                 },
                 "durable-workflow": {
-                    "product-train": "2.0.13",
+                    "product-train": "2.0.14",
                     "laravel-embedded-upgrade-contract": "resources/laravel-embedded-upgrade-contract.json",
                     "laravel-dependency-security-policy": "resources/laravel-dependency-security-policy.json"
                 }
@@ -988,9 +988,9 @@
             "description": "Embedded durable workflow runtime and orchestration engine for Laravel applications.",
             "support": {
                 "issues": "https://github.com/durable-workflow/workflow/issues",
-                "source": "https://github.com/durable-workflow/workflow/tree/2.0.13"
+                "source": "https://github.com/durable-workflow/workflow/tree/2.0.14"
             },
-            "time": "2026-09-11T19:03:42+00:00"
+            "time": "2026-09-12T09:18:29+00:00"
         },
         {
             "name": "egulias/email-validator",

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -7,7 +7,7 @@
     "sdk-php": "2.0.10",
     "sdk-python": "2.0.0",
     "sdk-rust": "2.0.1",
-    "server": "2.3.11",
+    "server": "2.3.12",
     "waterline": "2.0.0",
     "workflow": "2.0.14"
   }

--- a/polyglot/qualified-artifact-tuple.json
+++ b/polyglot/qualified-artifact-tuple.json
@@ -9,6 +9,6 @@
     "sdk-rust": "2.0.1",
     "server": "2.3.11",
     "waterline": "2.0.0",
-    "workflow": "2.0.13"
+    "workflow": "2.0.14"
   }
 }


### PR DESCRIPTION
## Change
Adopt published Workflow 2.0.14 for embedded execution and Server 2.3.12 for service mode. Update composer.lock and the existing qualified artifact tuple together. No SDK, Waterline, framework or other dependency update.

The engine fix prevents deadline arithmetic from mutating deterministic workflow time. Upstream: durable-workflow/workflow#512 and durable-workflow/server#163; delivery tracking: durable-workflow/workflow#511.

## Validation
- Published Workflow upgrade verification passed across supported Laravel/PHP combinations: https://github.com/durable-workflow/workflow/actions/runs/34685988306 .
- Independent installed-package clock/deadline regression passed on 2.0.14 (8 tests / 33 assertions) and reproduced five failures on 2.0.13.
- Server release verification passed: https://github.com/durable-workflow/server/actions/runs/34686666559 . The pulled immutable image contains Workflow source 259c32b86d132bdbac683e3bbc1de44251d45c5d and passes the clock ownership probe.
- Focused embedded and Laravel service-mode tests against MySQL passed: 8 tests / 44 assertions.
- Final-head CI application tests, Compose workflows and PHP/Python/Rust smoke passed against the new published image. Prepared development-image validation is the remaining check.

No new performance or SLA claim is made.